### PR TITLE
Upgrade dry-monads to ~> 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_struct (0.1.0)
+    api_struct (1.0.0)
       dry-configurable (~> 0.7.0)
       dry-monads (~> 1.0)
       hashie (~> 3.5, >= 3.5.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     api_struct (0.1.0)
       dry-configurable (~> 0.7.0)
-      dry-monads (~> 0.3.1)
+      dry-monads (~> 1.0)
       hashie (~> 3.5, >= 3.5.6)
       http (>= 2.0.3)
 
@@ -15,31 +15,32 @@ GEM
     ast (2.3.0)
     byebug (9.1.0)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
-    dry-core (0.4.1)
+    dry-core (0.4.7)
       concurrent-ruby (~> 1.0)
-    dry-equalizer (0.2.0)
-    dry-monads (0.3.1)
-      dry-core
+    dry-equalizer (0.2.1)
+    dry-monads (1.1.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer
     ffaker (2.8.0)
     hashdiff (0.3.7)
-    hashie (3.5.6)
-    http (3.0.0)
+    hashie (3.6.0)
+    http (4.0.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
-      http-form_data (>= 2.0.0.pre.pre2, < 3)
+      http-form_data (~> 2.0)
       http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (2.0.0)
+    http-form_data (2.1.1)
     http_parser.rb (0.6.0)
     method_source (0.9.0)
     parallel (1.12.0)
@@ -79,7 +80,7 @@ GEM
     safe_yaml (1.0.4)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
     vcr (3.0.3)
     webmock (3.2.1)
@@ -102,4 +103,4 @@ DEPENDENCIES
   webmock (~> 3.2, >= 3.2.1)
 
 BUNDLED WITH
-   1.16.0
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ class PostsClient < ApiStruct::Client
   def index
     get
   end
-  
+
   def user_posts(user_id, post_id = nil)
-    get(post_id, prefix: [:users, user_id]) 
-    # alias: 
+    get(post_id, prefix: [:users, user_id])
+    # alias:
     # get(post_id, prefix: '/users/:id', id: user_id)
   end
-  
+
   def custom_path(user_id)
     get(path: 'users_posts/:user_id', user_id: user_id)
   end
@@ -75,16 +75,16 @@ Usage:
 ```ruby
 PostsClient.new.get(1) # -> /posts/1
 ```
-Returns `Either` [monad](https://github.com/dry-rb/dry-monads)
+Returns `Result` [monad](https://dry-rb.org/gems/dry-monads/1.0/result/)
 ```ruby
-# => Right({:id=>1, :title=>"Post"})
+# => Success({:id=>1, :title=>"Post"})
 ```
 
 Other methods from sample:
 ```ruby
 post_client = PostsClient.new
 
-post_client.index            # -> /posts 
+post_client.index            # -> /posts
 post_client.user_posts(1)    # -> /users/1/posts
 post_client.user_posts(1, 2) # -> /users/1/posts/2
 post_client.custom_path(1)   # -> /users_posts/1/
@@ -99,9 +99,9 @@ class User < ApiStruct::Entity
   client_service UsersClient
 
   client_service AuthorsClient, prefix: true, only: :index
-  # alias: 
+  # alias:
   # client_service AuthorsClient, prefix: :prefix, except: :index
-  
+
   attr_entity :name, :id
 end
 ```

--- a/api_struct.gemspec
+++ b/api_struct.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dry-monads', '~> 0.3.1'
+  spec.add_dependency 'dry-monads', '~> 1.0'
   spec.add_dependency 'dry-configurable', '~> 0.7.0'
   spec.add_dependency 'http', '>= 2.0.3'
   spec.add_dependency 'hashie', '~> 3.5', '>= 3.5.6'

--- a/lib/api_struct.rb
+++ b/lib/api_struct.rb
@@ -1,5 +1,5 @@
 require 'http'
-require 'dry-monads'
+require 'dry/monads/result'
 require 'dry-configurable'
 require 'json'
 require 'hashie'

--- a/lib/api_struct/client.rb
+++ b/lib/api_struct/client.rb
@@ -1,8 +1,8 @@
 module ApiStruct
   class Client
-    DEFAULT_HEADERS = { 
+    DEFAULT_HEADERS = {
       'Accept': 'application/json',
-      'Content-Type': 'application/json' 
+      'Content-Type': 'application/json'
     }
     URL_OPTION_REGEXP = /\/:([a-z_]+)/.freeze
 
@@ -47,12 +47,12 @@ module ApiStruct
     def success(response)
       body = response.body.to_s
       result = !body.empty? ? JSON.parse(body, symbolize_names: true) : nil
-      Dry::Monads.Right(result)
+      Dry::Monads::Success(result)
     end
 
     def failure(response)
       result = ApiStruct::Errors::Client.new(response)
-      Dry::Monads.Left(result)
+      Dry::Monads::Failure(result)
     end
 
     def first_arg(args)

--- a/lib/api_struct/extensions/dry_monads.rb
+++ b/lib/api_struct/extensions/dry_monads.rb
@@ -2,16 +2,20 @@ module ApiStruct
   module Extensions
     module DryMonads
       def from_monad(monad)
-        monad.fmap { |v| from_right(v) }.or_fmap { |e| from_left(e) }.value
+        monad
+          .fmap { |v| from_success(v) }.or_fmap { |e| from_failure(e) }.value!
       end
 
-      def from_right(value)
-        return Dry::Monads::Right(nil) if value.nil?
+      def from_success(value)
+        return Dry::Monads::Success(nil) if value.nil?
+
         value.is_a?(Array) ? collection(value) : new(value)
       end
 
-      def from_left(error)
-        ApiStruct::Errors::Entity.new({ status: error.status, body: error.body, error: true }, false)
+      def from_failure(error)
+        ApiStruct::Errors::Entity.new(
+          { status: error.status, body: error.body, error: true }, false
+        )
       end
     end
   end

--- a/lib/api_struct/version.rb
+++ b/lib/api_struct/version.rb
@@ -1,3 +1,3 @@
 module ApiStruct
-  VERSION = '0.1.0'
+  VERSION = '1.0.0'
 end

--- a/spec/api_struct/client_spec.rb
+++ b/spec/api_struct/client_spec.rb
@@ -9,7 +9,7 @@ describe ApiStruct::Client do
     def show(id)
       get(id)
     end
-    
+
     def update(id, params)
       patch(id, json: params)
     end
@@ -61,8 +61,8 @@ describe ApiStruct::Client do
       VCR.use_cassette('users/1/posts') do
         response = StubClient.new.get(prefix: 'users/:id', id: 1)
         expect(response).to be_success
-        expect(response.value).to be_kind_of Array
-        expect(response.value).not_to be_empty
+        expect(response.value!).to be_kind_of Array
+        expect(response.value!).not_to be_empty
       end
     end
 
@@ -70,9 +70,9 @@ describe ApiStruct::Client do
       VCR.use_cassette('todos') do
         response = StubClient.new.get(path: 'todos/1')
         expect(response).to be_success
-        expect(response.value[:id]).to eq(1)
-        expect(response.value[:title]).not_to be_empty
-        expect(response.value.keys).to include(:completed)
+        expect(response.value![:id]).to eq(1)
+        expect(response.value![:title]).not_to be_empty
+        expect(response.value!.keys).to include(:completed)
       end
     end
 
@@ -80,20 +80,20 @@ describe ApiStruct::Client do
       VCR.use_cassette('todos') do
         response = StubClient.new.get(path: [:todos, 1])
         expect(response).to be_success
-        expect(response.value[:id]).to eq(1)
-        expect(response.value[:title]).not_to be_empty
-        expect(response.value.keys).to include(:completed)
+        expect(response.value![:id]).to eq(1)
+        expect(response.value![:title]).not_to be_empty
+        expect(response.value!.keys).to include(:completed)
       end
     end
   end
-  
+
   context 'GET' do
     it 'when successful response' do
       VCR.use_cassette('posts/show_success') do
         response = StubClient.new.show(1)
         expect(response).to be_success
-        expect(response.value[:id]).to eq(1)
-        expect(response.value[:title]).not_to be_empty
+        expect(response.value![:id]).to eq(1)
+        expect(response.value![:title]).not_to be_empty
       end
     end
 
@@ -101,7 +101,7 @@ describe ApiStruct::Client do
       VCR.use_cassette('posts/show_failure') do
         response = StubClient.new.show(101)
         expect(response).to be_failure
-        expect(response.value.status).to eq(404)
+        expect(response.failure.status).to eq(404)
       end
     end
   end
@@ -111,7 +111,7 @@ describe ApiStruct::Client do
       VCR.use_cassette('posts/update_success') do
         response = StubClient.new.update(1, title: FFaker::Name.name)
         expect(response).to be_success
-        expect(response.value[:id]).to eq(1)
+        expect(response.value![:id]).to eq(1)
       end
     end
   end


### PR DESCRIPTION
This is an improvement in terms of using newer codebase, and also for those who are already using newer `dry-monads` in their projects.

Perhaps it would be nice to also have `CHANGELOG.md` file, and document there the difference between `api_struct` versions 0.1.0 and 1.0.0