### PR TITLE
returns error body if it is impossible to parse JSON

### DIFF
--- a/lib/api_struct/errors/client.rb
+++ b/lib/api_struct/errors/client.rb
@@ -35,6 +35,8 @@ module ApiStruct
 
       def parse_body(b)
         !b.empty? ? JSON.parse(b, symbolize_names: true) : nil
+      rescue JSON::ParserError
+        b
       end
     end
   end

--- a/spec/api_struct/client_spec.rb
+++ b/spec/api_struct/client_spec.rb
@@ -104,6 +104,17 @@ describe ApiStruct::Client do
         expect(response.failure.status).to eq(404)
       end
     end
+
+    it 'when failed response with html response' do
+      VCR.use_cassette('posts/show_failure_html') do
+        response = StubClient.new.show(101)
+        body     = response.failure.body
+        expect(response).to be_failure
+        expect(response.failure.status).to eq(404)
+        expect(body).to be_kind_of(String)
+        expect(body).to match(/<body>.+<\/body>/)
+      end
+    end
   end
 
   context 'PATCH' do

--- a/spec/fixtures/cassettes/posts/show_failure_html.yml
+++ b/spec/fixtures/cassettes/posts/show_failure_html.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://jsonplaceholder.typicode.com/posts/101
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - jsonplaceholder.typicode.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 18 Jan 2018 19:23:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '27'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dea576b2c58beb4acebfa8cc1b8f3cd731516303417; expires=Fri, 18-Jan-19
+        19:23:37 GMT; path=/; domain=.typicode.com; HttpOnly
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - public, max-age=14400
+      Pragma:
+      - no-cache
+      Expires:
+      - Thu, 18 Jan 2018 23:23:37 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - EXPIRED
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3df3ee046ef84f20-DME
+    body:
+      encoding: UTF-8
+      string: "<body>404. Not Found</body>"
+    http_version:
+  recorded_at: Thu, 18 Jan 2018 19:23:37 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Hi. I'm writing wrapper for YandexKassa API and realized that sometimes I get `JSON::ParserError` for failed requests. It happens because API responds with HTML page. So, in this case it is impossible to parse JSON from HTML and I guess it would be nice if we just use raw response body.